### PR TITLE
Fixing issue with fallback fucntion

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,9 +53,12 @@ module.exports = async function (channel, message, options) {
     if (isNaN(options.delete)) options.delete = false;
 
     // Fetch Webhooks
+    let sended = false;
     let webhooks = await channel.fetchWebhooks().catch(err => {
+        sended = true;
         fallback(channel, message, options.delete)
     });
+    if(sended) return;
 
     // Assign Webhook
     let hook = webhooks.find('name', 'https://discord.io/plexidev')


### PR DESCRIPTION
The issue is that if the bot doesn't have perms to get the webhooks it will fallback and since it is not returned properly it sends the msg twice