### PR TITLE
Fixing index.js avatar url not being found

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,10 +69,10 @@ module.exports = async function (channel, message, options) {
     if (!hook) {
         try {
             hook = await channel.createWebhook('https://discord.gg/plexidev', {
-                avatar: 'https://pbs.twimg.com/profile_images/944717552290226176/zBF2n9zr_400x400.jpg'
+                avatar: 'https://cdn.discordapp.com/icons/343572980351107077/5afb9e4d2eb0f09ada16bd129ebf422f.png?size=512'
             });
         } catch (e) {
-            hook = await channel.createWebhook('https://discord.gg/plexidev', 'https://pbs.twimg.com/profile_images/944717552290226176/zBF2n9zr_400x400.jpg');
+            hook = await channel.createWebhook('https://discord.gg/plexidev', 'https://cdn.discordapp.com/icons/343572980351107077/5afb9e4d2eb0f09ada16bd129ebf422f.png?size=512');
         }
         return sendHook(hook, message, options);
     }


### PR DESCRIPTION
There currently is an error with quick.hook whenever you try to send a webhook to a channel where it isnt set up yet because the url to the avatar doesnt exist anymore. I replaced that url with the url to the icon of the Plexi Dev discord.